### PR TITLE
Dummy가 죽으면 config.yml에서 설정한 시간 뒤에 리젠되도록 하기

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.teamuni</groupId>
     <artifactId>ShootingTest</artifactId>
-    <version>0.0.6</version>
+    <version>0.0.7</version>
     <packaging>jar</packaging>
 
     <name>ShootingTest</name>

--- a/src/main/java/net/teamuni/shootingtest/RespawnTask.java
+++ b/src/main/java/net/teamuni/shootingtest/RespawnTask.java
@@ -1,0 +1,25 @@
+package net.teamuni.shootingtest;
+
+import net.citizensnpcs.api.event.SpawnReason;
+import net.citizensnpcs.api.npc.NPC;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+
+public class RespawnTask implements Runnable {
+    private final NPC dummy;
+    private final Location loc;
+
+    public RespawnTask(NPC npc, Location location) {
+        this.dummy = npc;
+        this.loc = location;
+    }
+
+    @Override
+    public void run() {
+        dummy.spawn(loc, SpawnReason.RESPAWN);
+    }
+
+    public void register(ShootingTest plugin, long delay) {
+        Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, this, delay);
+    }
+}

--- a/src/main/java/net/teamuni/shootingtest/ShootingTest.java
+++ b/src/main/java/net/teamuni/shootingtest/ShootingTest.java
@@ -7,6 +7,7 @@ import net.teamuni.shootingtest.command.ShootingTestCmd;
 import net.teamuni.shootingtest.config.DummyManager;
 import net.teamuni.shootingtest.config.ItemManager;
 import net.teamuni.shootingtest.config.MessageManager;
+import net.teamuni.shootingtest.events.DummyDamage;
 import net.teamuni.shootingtest.events.DummySpawn;
 import net.teamuni.shootingtest.events.PlayerTeleport;
 import org.bukkit.Bukkit;
@@ -20,6 +21,7 @@ public final class ShootingTest extends JavaPlugin {
     private MessageManager messageManager;
     private DummyManager dummyManager;
     private ShootingTestInv inventory;
+    private DummySpawn dummySpawn;
 
     @Override
     public void onEnable() {
@@ -27,10 +29,12 @@ public final class ShootingTest extends JavaPlugin {
         this.itemManager = new ItemManager(this);
         this.dummyManager = new DummyManager(this);
         this.inventory = new ShootingTestInv(this);
+        this.dummySpawn = new DummySpawn(this);
         saveDefaultConfig();
         Bukkit.getPluginManager().registerEvents(new PlayerTeleport(this), this);
         Bukkit.getPluginManager().registerEvents(this.inventory, this);
-        Bukkit.getPluginManager().registerEvents(new DummySpawn(this), this);
+        Bukkit.getPluginManager().registerEvents(this.dummySpawn, this);
+        Bukkit.getPluginManager().registerEvents(new DummyDamage(this), this);
         getCommand("st").setExecutor(new ShootingTestCmd(this));
         getCommand("st").setTabCompleter(new CommandTabCompleter());
         getCommand("dummy").setExecutor(new DummyCmd(this));

--- a/src/main/java/net/teamuni/shootingtest/ShootingTest.java
+++ b/src/main/java/net/teamuni/shootingtest/ShootingTest.java
@@ -8,7 +8,7 @@ import net.teamuni.shootingtest.config.DummyManager;
 import net.teamuni.shootingtest.config.ItemManager;
 import net.teamuni.shootingtest.config.MessageManager;
 import net.teamuni.shootingtest.events.DummyDamage;
-import net.teamuni.shootingtest.events.DummySpawn;
+import net.teamuni.shootingtest.events.DummyRespawn;
 import net.teamuni.shootingtest.events.PlayerTeleport;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -21,7 +21,7 @@ public final class ShootingTest extends JavaPlugin {
     private MessageManager messageManager;
     private DummyManager dummyManager;
     private ShootingTestInv inventory;
-    private DummySpawn dummySpawn;
+    private DummyRespawn dummyRespawn;
 
     @Override
     public void onEnable() {
@@ -29,11 +29,11 @@ public final class ShootingTest extends JavaPlugin {
         this.itemManager = new ItemManager(this);
         this.dummyManager = new DummyManager(this);
         this.inventory = new ShootingTestInv(this);
-        this.dummySpawn = new DummySpawn(this);
+        this.dummyRespawn = new DummyRespawn(this);
         saveDefaultConfig();
         Bukkit.getPluginManager().registerEvents(new PlayerTeleport(this), this);
         Bukkit.getPluginManager().registerEvents(this.inventory, this);
-        Bukkit.getPluginManager().registerEvents(this.dummySpawn, this);
+        Bukkit.getPluginManager().registerEvents(this.dummyRespawn, this);
         Bukkit.getPluginManager().registerEvents(new DummyDamage(this), this);
         getCommand("st").setExecutor(new ShootingTestCmd(this));
         getCommand("st").setTabCompleter(new CommandTabCompleter());

--- a/src/main/java/net/teamuni/shootingtest/ShootingTest.java
+++ b/src/main/java/net/teamuni/shootingtest/ShootingTest.java
@@ -7,6 +7,7 @@ import net.teamuni.shootingtest.command.ShootingTestCmd;
 import net.teamuni.shootingtest.config.DummyManager;
 import net.teamuni.shootingtest.config.ItemManager;
 import net.teamuni.shootingtest.config.MessageManager;
+import net.teamuni.shootingtest.events.DummySpawn;
 import net.teamuni.shootingtest.events.PlayerTeleport;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -29,6 +30,7 @@ public final class ShootingTest extends JavaPlugin {
         saveDefaultConfig();
         Bukkit.getPluginManager().registerEvents(new PlayerTeleport(this), this);
         Bukkit.getPluginManager().registerEvents(new ShootingTestInv(this), this);
+        Bukkit.getPluginManager().registerEvents(new DummySpawn(this), this);
         getCommand("st").setExecutor(new ShootingTestCmd(this));
         getCommand("st").setTabCompleter(new CommandTabCompleter());
         getCommand("dummy").setExecutor(new DummyCmd(this));

--- a/src/main/java/net/teamuni/shootingtest/ShootingTest.java
+++ b/src/main/java/net/teamuni/shootingtest/ShootingTest.java
@@ -29,7 +29,7 @@ public final class ShootingTest extends JavaPlugin {
         this.inventory = new ShootingTestInv(this);
         saveDefaultConfig();
         Bukkit.getPluginManager().registerEvents(new PlayerTeleport(this), this);
-        Bukkit.getPluginManager().registerEvents(new ShootingTestInv(this), this);
+        Bukkit.getPluginManager().registerEvents(this.inventory, this);
         Bukkit.getPluginManager().registerEvents(new DummySpawn(this), this);
         getCommand("st").setExecutor(new ShootingTestCmd(this));
         getCommand("st").setTabCompleter(new CommandTabCompleter());

--- a/src/main/java/net/teamuni/shootingtest/ShootingTest.java
+++ b/src/main/java/net/teamuni/shootingtest/ShootingTest.java
@@ -40,6 +40,10 @@ public final class ShootingTest extends JavaPlugin {
             getLogger().log(Level.SEVERE, "Citizens is not found or not enabled");
             getServer().getPluginManager().disablePlugin(this);
         }
+        if (!getServer().getPluginManager().getPlugin("GunsCore").isEnabled()) {
+            getLogger().log(Level.SEVERE, "GunsCore is not found or not enabled");
+            getServer().getPluginManager().disablePlugin(this);
+        }
     }
 
     @Override

--- a/src/main/java/net/teamuni/shootingtest/command/ShootingTestCmd.java
+++ b/src/main/java/net/teamuni/shootingtest/command/ShootingTestCmd.java
@@ -16,8 +16,7 @@ public class ShootingTestCmd implements CommandExecutor {
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        if (sender instanceof Player) {
-            Player player = (Player) sender;
+        if (sender instanceof Player player) {
 
             if (command.getName().equalsIgnoreCase("st") && args[0].equalsIgnoreCase("reload")
                     && player.hasPermission("st.manage")) {

--- a/src/main/java/net/teamuni/shootingtest/command/ShootingTestCmd.java
+++ b/src/main/java/net/teamuni/shootingtest/command/ShootingTestCmd.java
@@ -23,6 +23,7 @@ public class ShootingTestCmd implements CommandExecutor {
                 main.reloadConfig();
                 main.getMessageManager().reload();
                 main.getItemManager().reload();
+                main.getDummyRespawn().respawnDummies();
                 for (String reloadMessages : main.getMessageManager().getConfig().getStringList("reload_message")) {
                     player.sendMessage(ChatColor.translateAlternateColorCodes('&', reloadMessages));
                 }

--- a/src/main/java/net/teamuni/shootingtest/config/DummyManager.java
+++ b/src/main/java/net/teamuni/shootingtest/config/DummyManager.java
@@ -109,7 +109,11 @@ public class DummyManager {
     public void setDummyHealth(LivingEntity entity) {
         AttributeInstance maxHealth = entity.getAttribute(Attribute.GENERIC_MAX_HEALTH);
         if (maxHealth == null) return;
-        maxHealth.setBaseValue(main.getConfig().getDouble("dummy_health"));
+        double health = main.getConfig().getDouble("dummy_health");
+        if (health <= 0) {
+            health = 1;
+        }
+        maxHealth.setBaseValue(health);
         entity.setHealth(maxHealth.getBaseValue());
     }
 

--- a/src/main/java/net/teamuni/shootingtest/config/DummyManager.java
+++ b/src/main/java/net/teamuni/shootingtest/config/DummyManager.java
@@ -91,7 +91,7 @@ public class DummyManager {
             return;
         }
         section.set(name, null);
-        this.reload();
+        this.save();
 
         NPC npc = CitizensAPI.getNPCRegistry().getByUniqueId(UUID.fromString(npcUUID));
         if (npc == null) return;

--- a/src/main/java/net/teamuni/shootingtest/config/DummyManager.java
+++ b/src/main/java/net/teamuni/shootingtest/config/DummyManager.java
@@ -7,6 +7,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.EntityType;
@@ -61,7 +62,8 @@ public class DummyManager {
     }
 
     public void createDummy(Player player, String name, Location location) {
-        Set<String> npcs = main.getDummyManager().getConfig().getConfigurationSection("dummy").getKeys(false);
+        ConfigurationSection section = this.dummyFile.getConfigurationSection("dummy");
+        Set<String> npcs = section.getKeys(false);
         if (npcs.contains(name)) {
             String message = main.getMessageManager().getConfig().getString("dummy_already_exist", "&cThe name of dummy already exist!");
             player.sendMessage(ChatColor.translateAlternateColorCodes('&', message));
@@ -74,21 +76,22 @@ public class DummyManager {
 
         LivingEntity entity = (LivingEntity) npc.getEntity();
         this.setDummyHealth(entity);
-        main.getDummyManager().getConfig().set("dummy." + name, npc.getUniqueId().toString());
+        section.set(name, npc.getUniqueId().toString());
 
         String message = main.getMessageManager().getConfig().getString("dummy_created", "&aDummy has been created successfully!");
         player.sendMessage(ChatColor.translateAlternateColorCodes('&', message));
     }
 
     public void removeDummy(Player player, String name) {
-        String npcUUID = main.getDummyManager().getConfig().getString("dummy." + name);
+        ConfigurationSection section = this.dummyFile.getConfigurationSection("dummy");
+        String npcUUID = section.getString(name);
         if (npcUUID == null) {
             String message = main.getMessageManager().getConfig().getString("dummy_not_exist", "&cDummy try to remove does not exist!");
             player.sendMessage(ChatColor.translateAlternateColorCodes('&', message));
             return;
         }
-        main.getDummyManager().getConfig().set("dummy." + name, null);
-        main.getDummyManager().reload();
+        section.set(name, null);
+        this.reload();
 
         NPC npc = CitizensAPI.getNPCRegistry().getByUniqueId(UUID.fromString(npcUUID));
         if (npc == null) return;

--- a/src/main/java/net/teamuni/shootingtest/config/DummyManager.java
+++ b/src/main/java/net/teamuni/shootingtest/config/DummyManager.java
@@ -23,10 +23,12 @@ public class DummyManager {
     private final ShootingTest main;
     private File file = null;
     private FileConfiguration dummyFile = null;
+    private final ConfigurationSection section;
 
     public DummyManager(ShootingTest instance) {
         this.main = instance;
         createDummyYml();
+        this.section = this.dummyFile.getConfigurationSection("dummy");
     }
 
     public void createDummyYml() {
@@ -62,7 +64,6 @@ public class DummyManager {
     }
 
     public void createDummy(Player player, String name, Location location) {
-        ConfigurationSection section = this.dummyFile.getConfigurationSection("dummy");
         Set<String> npcs = section.getKeys(false);
         if (npcs.contains(name)) {
             String message = main.getMessageManager().getConfig().getString("dummy_already_exist", "&cThe name of dummy already exist!");
@@ -83,7 +84,6 @@ public class DummyManager {
     }
 
     public void removeDummy(Player player, String name) {
-        ConfigurationSection section = this.dummyFile.getConfigurationSection("dummy");
         String npcUUID = section.getString(name);
         if (npcUUID == null) {
             String message = main.getMessageManager().getConfig().getString("dummy_not_exist", "&cDummy try to remove does not exist!");

--- a/src/main/java/net/teamuni/shootingtest/config/DummyManager.java
+++ b/src/main/java/net/teamuni/shootingtest/config/DummyManager.java
@@ -74,7 +74,7 @@ public class DummyManager {
 
         NPC dummy = CitizensAPI.getNPCRegistry().createNPC(EntityType.ZOMBIE, name);
         this.createDummyInfo(section, dummy, name, location);
-        main.getDummySpawn().getDummies().add(dummy);
+        main.getDummyRespawn().getDummies().add(dummy);
         dummy.spawn(location, SpawnReason.CREATE);
         dummy.setProtected(false);
 

--- a/src/main/java/net/teamuni/shootingtest/events/DummyDamage.java
+++ b/src/main/java/net/teamuni/shootingtest/events/DummyDamage.java
@@ -20,7 +20,7 @@ public class DummyDamage implements Listener {
         Entity entity = event.getEntity();
         NPC dummy = CitizensAPI.getNPCRegistry().getByUniqueId(entity.getUniqueId());
         if (dummy == null) return;
-        if (!main.getDummySpawn().getDummies().contains(dummy)) return;
+        if (!main.getDummyRespawn().getDummies().contains(dummy)) return;
         entity.setFireTicks(0);
         event.setCancelled(true);
     }

--- a/src/main/java/net/teamuni/shootingtest/events/DummyDamage.java
+++ b/src/main/java/net/teamuni/shootingtest/events/DummyDamage.java
@@ -1,0 +1,27 @@
+package net.teamuni.shootingtest.events;
+
+import net.citizensnpcs.api.CitizensAPI;
+import net.citizensnpcs.api.npc.NPC;
+import net.teamuni.shootingtest.ShootingTest;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+
+public class DummyDamage implements Listener {
+    private final ShootingTest main;
+    public DummyDamage(ShootingTest instance) {
+        this.main = instance;
+    }
+
+    @EventHandler
+    public void onDamage(EntityDamageEvent event) {
+        if (event.getCause() != EntityDamageEvent.DamageCause.FIRE_TICK) return;
+        Entity entity = event.getEntity();
+        NPC dummy = CitizensAPI.getNPCRegistry().getByUniqueId(entity.getUniqueId());
+        if (dummy == null) return;
+        if (!main.getDummySpawn().getDummies().contains(dummy)) return;
+        entity.setFireTicks(0);
+        event.setCancelled(true);
+    }
+}

--- a/src/main/java/net/teamuni/shootingtest/events/DummyRespawn.java
+++ b/src/main/java/net/teamuni/shootingtest/events/DummyRespawn.java
@@ -65,7 +65,7 @@ public class DummyRespawn implements Listener {
                 (float) section1.getDouble("pitch"));
 
         runnableMap.remove(dummy).cancel();
-        this.scheduleRespawn(dummy, dummyLoc);
+        scheduleRespawn(dummy, dummyLoc);
     }
 
     public void loadDummies() {

--- a/src/main/java/net/teamuni/shootingtest/events/DummyRespawn.java
+++ b/src/main/java/net/teamuni/shootingtest/events/DummyRespawn.java
@@ -19,13 +19,13 @@ import org.bukkit.util.Vector;
 
 import java.util.*;
 
-public class DummySpawn implements Listener {
+public class DummyRespawn implements Listener {
     private final ShootingTest main;
     @Getter
     private final Set<NPC> dummies = new HashSet<>();
     private final Map<NPC, BukkitRunnable> runnableMap = new HashMap<>();
 
-    public DummySpawn(ShootingTest instance) {
+    public DummyRespawn(ShootingTest instance) {
         this.main = instance;
         this.loadDummies();
     }

--- a/src/main/java/net/teamuni/shootingtest/events/DummyRespawn.java
+++ b/src/main/java/net/teamuni/shootingtest/events/DummyRespawn.java
@@ -2,6 +2,7 @@ package net.teamuni.shootingtest.events;
 
 import lombok.Getter;
 import net.citizensnpcs.api.CitizensAPI;
+import net.citizensnpcs.api.event.DespawnReason;
 import net.citizensnpcs.api.event.NPCSpawnEvent;
 import net.citizensnpcs.api.event.SpawnReason;
 import net.citizensnpcs.api.npc.NPC;
@@ -54,18 +55,8 @@ public class DummyRespawn implements Listener {
         if (dummy == null) return;
         if (!dummies.contains(dummy)) return;
 
-        ConfigurationSection section = main.getDummyManager().getConfig().getConfigurationSection("dummy." + dummy.getName());
-        ConfigurationSection section1 = section.getConfigurationSection("location");
-        Location dummyLoc = new Location(
-                Bukkit.getServer().getWorld(section1.getString("world")),
-                section1.getDouble("x"),
-                section1.getDouble("y"),
-                section1.getDouble("z"),
-                (float) section1.getDouble("yaw"),
-                (float) section1.getDouble("pitch"));
-
         runnableMap.remove(dummy).cancel();
-        scheduleRespawn(dummy, dummyLoc);
+        scheduleRespawn(dummy, getLocation(dummy));
     }
 
     public void loadDummies() {
@@ -95,5 +86,25 @@ public class DummyRespawn implements Listener {
             delay = 21;
         }
         new RespawnTask(npc, location).register(main, delay);
+    }
+
+    public void respawnDummies() {
+        for (NPC dummy : dummies) {
+            dummy.despawn(DespawnReason.PENDING_RESPAWN);
+            dummy.spawn(getLocation(dummy), SpawnReason.RESPAWN);
+        }
+    }
+
+    public Location getLocation(NPC dummy) {
+        ConfigurationSection section = main.getDummyManager().getConfig().getConfigurationSection("dummy." + dummy.getName());
+        ConfigurationSection section1 = section.getConfigurationSection("location");
+
+        return new Location(
+                Bukkit.getServer().getWorld(section1.getString("world")),
+                section1.getDouble("x"),
+                section1.getDouble("y"),
+                section1.getDouble("z"),
+                (float) section1.getDouble("yaw"),
+                (float) section1.getDouble("pitch"));
     }
 }

--- a/src/main/java/net/teamuni/shootingtest/events/DummyRespawn.java
+++ b/src/main/java/net/teamuni/shootingtest/events/DummyRespawn.java
@@ -54,6 +54,7 @@ public class DummyRespawn implements Listener {
         NPC dummy = CitizensAPI.getNPCRegistry().getByUniqueId(event.getEntity().getUniqueId());
         if (dummy == null) return;
         if (!dummies.contains(dummy)) return;
+        event.setDroppedExp(0);
 
         runnableMap.remove(dummy).cancel();
         scheduleRespawn(dummy, getLocation(dummy));

--- a/src/main/java/net/teamuni/shootingtest/events/DummySpawn.java
+++ b/src/main/java/net/teamuni/shootingtest/events/DummySpawn.java
@@ -11,9 +11,7 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 public class DummySpawn implements Listener {
     private final ShootingTest main;
@@ -26,9 +24,10 @@ public class DummySpawn implements Listener {
 
     @EventHandler
     public void onEntitySpawn(NPCSpawnEvent event) {
-        if (dummies.contains(event.getNPC())) {
+        NPC npc = event.getNPC();
+        if (dummies.contains(npc)) {
             if (event.getReason() == SpawnReason.COMMAND || event.getReason() == SpawnReason.RESPAWN || event.getReason() == SpawnReason.CHUNK_LOAD) {
-                LivingEntity entity = (LivingEntity) event.getNPC().getEntity();
+                LivingEntity entity = (LivingEntity) npc.getEntity();
                 main.getDummyManager().setDummyHealth(entity);
             }
         }

--- a/src/main/java/net/teamuni/shootingtest/events/DummySpawn.java
+++ b/src/main/java/net/teamuni/shootingtest/events/DummySpawn.java
@@ -47,7 +47,7 @@ public class DummySpawn implements Listener {
 
                 ++numNPCs;
             }
-            Bukkit.getLogger().info("[ShootingTest] Get " + numNPCs + " Dummies' info.");
+            Bukkit.getLogger().info("[ShootingTest] Loaded " + numNPCs + " dummy(ies).");
         }, 1L);
     }
 }

--- a/src/main/java/net/teamuni/shootingtest/events/DummySpawn.java
+++ b/src/main/java/net/teamuni/shootingtest/events/DummySpawn.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 
 public class DummySpawn implements Listener {
     private final ShootingTest main;
-    private final List<NPC> npcs = new ArrayList<>();
+    private final List<NPC> dummies = new ArrayList<>();
 
     public DummySpawn(ShootingTest instance) {
         this.main = instance;
@@ -26,7 +26,7 @@ public class DummySpawn implements Listener {
 
     @EventHandler
     public void onEntitySpawn(NPCSpawnEvent event) {
-        if (npcs.contains(event.getNPC())) {
+        if (dummies.contains(event.getNPC())) {
             if (event.getReason() == SpawnReason.COMMAND || event.getReason() == SpawnReason.RESPAWN || event.getReason() == SpawnReason.CHUNK_LOAD) {
                 LivingEntity entity = (LivingEntity) event.getNPC().getEntity();
                 main.getDummyManager().setDummyHealth(entity);
@@ -43,11 +43,11 @@ public class DummySpawn implements Listener {
                 if (npcUUID == null) continue;
                 NPC npc = CitizensAPI.getNPCRegistry().getByUniqueId(UUID.fromString(npcUUID));
                 if (npc == null) continue;
-                npcs.add(npc);
+                dummies.add(npc);
 
                 ++numNPCs;
             }
             Bukkit.getLogger().info("[ShootingTest] Get " + numNPCs + " Dummies' info.");
-        }, 5);
+        }, 1L);
     }
 }

--- a/src/main/java/net/teamuni/shootingtest/events/DummySpawn.java
+++ b/src/main/java/net/teamuni/shootingtest/events/DummySpawn.java
@@ -1,52 +1,99 @@
 package net.teamuni.shootingtest.events;
 
+import lombok.Getter;
 import net.citizensnpcs.api.CitizensAPI;
 import net.citizensnpcs.api.event.NPCSpawnEvent;
 import net.citizensnpcs.api.event.SpawnReason;
 import net.citizensnpcs.api.npc.NPC;
+import net.teamuni.shootingtest.RespawnTask;
 import net.teamuni.shootingtest.ShootingTest;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.Vector;
 
 import java.util.*;
 
 public class DummySpawn implements Listener {
     private final ShootingTest main;
-    private final List<NPC> dummies = new ArrayList<>();
+    @Getter
+    private final Set<NPC> dummies = new HashSet<>();
+    private final Map<NPC, BukkitRunnable> runnableMap = new HashMap<>();
 
     public DummySpawn(ShootingTest instance) {
         this.main = instance;
-        this.getNPCs();
+        this.loadDummies();
     }
 
     @EventHandler
-    public void onEntitySpawn(NPCSpawnEvent event) {
-        NPC npc = event.getNPC();
-        if (dummies.contains(npc)) {
-            if (event.getReason() == SpawnReason.COMMAND || event.getReason() == SpawnReason.RESPAWN || event.getReason() == SpawnReason.CHUNK_LOAD) {
-                LivingEntity entity = (LivingEntity) npc.getEntity();
-                main.getDummyManager().setDummyHealth(entity);
-            }
+    public void onSpawn(NPCSpawnEvent event) {
+        NPC dummy = CitizensAPI.getNPCRegistry().getByUniqueId(event.getNPC().getUniqueId());
+        if (!dummies.contains(dummy)) return;
+        if (Arrays.asList(SpawnReason.values()).contains(event.getReason())) {
+            LivingEntity entity = (LivingEntity) dummy.getEntity();
+            main.getDummyManager().setDummyHealth(entity);
+            BukkitRunnable runnable = new BukkitRunnable() {
+                @Override
+                public void run() {
+                    entity.setVelocity(new Vector(0, 0, 0));
+                }
+            };
+            runnable.runTaskTimer(main, 1L, 1L);
+            runnableMap.put(dummy, runnable);
         }
     }
 
-    public void getNPCs() {
+    @EventHandler
+    public void onDeath(EntityDeathEvent event) {
+        NPC dummy = CitizensAPI.getNPCRegistry().getByUniqueId(event.getEntity().getUniqueId());
+        if (dummy == null) return;
+        if (!dummies.contains(dummy)) return;
+
+        ConfigurationSection section = main.getDummyManager().getConfig().getConfigurationSection("dummy." + dummy.getName());
+        ConfigurationSection section1 = section.getConfigurationSection("location");
+        Location dummyLoc = new Location(
+                Bukkit.getServer().getWorld(section1.getString("world")),
+                section1.getDouble("x"),
+                section1.getDouble("y"),
+                section1.getDouble("z"),
+                (float) section1.getDouble("yaw"),
+                (float) section1.getDouble("pitch"));
+
+        runnableMap.remove(dummy).cancel();
+        this.scheduleRespawn(dummy, dummyLoc);
+    }
+
+    public void loadDummies() {
         Bukkit.getScheduler().scheduleSyncDelayedTask(main, () -> {
             ConfigurationSection section = main.getDummyManager().getConfig().getConfigurationSection("dummy");
-            int numNPCs = 0;
+            int numDummies = 0;
             for (String key : section.getKeys(false)) {
-                String npcUUID = section.getString(key);
+                ConfigurationSection section1 = section.getConfigurationSection(key);
+                if (section1 == null) continue;
+                String npcUUID = section1.getString("uuid");
                 if (npcUUID == null) continue;
                 NPC npc = CitizensAPI.getNPCRegistry().getByUniqueId(UUID.fromString(npcUUID));
                 if (npc == null) continue;
+                LivingEntity entity = (LivingEntity) npc.getEntity();
+                if (entity == null) continue;
                 dummies.add(npc);
 
-                ++numNPCs;
+                ++numDummies;
             }
-            Bukkit.getLogger().info("[ShootingTest] Loaded " + numNPCs + " dummy(ies).");
+            Bukkit.getLogger().info("[ShootingTest] Loaded " + numDummies + " dummy(ies).");
         }, 1L);
+    }
+
+    public void scheduleRespawn(NPC npc, Location location) {
+        long delay = main.getConfig().getLong("dummy_respawn_delay");
+        if (delay <= 20) {
+            delay = 21;
+        }
+        new RespawnTask(npc, location).register(main, delay);
     }
 }

--- a/src/main/java/net/teamuni/shootingtest/events/DummySpawn.java
+++ b/src/main/java/net/teamuni/shootingtest/events/DummySpawn.java
@@ -1,0 +1,53 @@
+package net.teamuni.shootingtest.events;
+
+import net.citizensnpcs.api.CitizensAPI;
+import net.citizensnpcs.api.event.NPCSpawnEvent;
+import net.citizensnpcs.api.event.SpawnReason;
+import net.citizensnpcs.api.npc.NPC;
+import net.teamuni.shootingtest.ShootingTest;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class DummySpawn implements Listener {
+    private final ShootingTest main;
+    private final List<NPC> npcs = new ArrayList<>();
+
+    public DummySpawn(ShootingTest instance) {
+        this.main = instance;
+        this.getNPCs();
+    }
+
+    @EventHandler
+    public void onEntitySpawn(NPCSpawnEvent event) {
+        if (npcs.contains(event.getNPC())) {
+            if (event.getReason() == SpawnReason.COMMAND || event.getReason() == SpawnReason.RESPAWN || event.getReason() == SpawnReason.CHUNK_LOAD) {
+                LivingEntity entity = (LivingEntity) event.getNPC().getEntity();
+                main.getDummyManager().setDummyHealth(entity);
+            }
+        }
+    }
+
+    public void getNPCs() {
+        Bukkit.getScheduler().scheduleSyncDelayedTask(main, () -> {
+            ConfigurationSection section = main.getDummyManager().getConfig().getConfigurationSection("dummy");
+            int numNPCs = 0;
+            for (String key : section.getKeys(false)) {
+                String npcUUID = section.getString(key);
+                if (npcUUID == null) continue;
+                NPC npc = CitizensAPI.getNPCRegistry().getByUniqueId(UUID.fromString(npcUUID));
+                if (npc == null) continue;
+                npcs.add(npc);
+
+                ++numNPCs;
+            }
+            Bukkit.getLogger().info("[ShootingTest] Get " + numNPCs + " Dummies' info.");
+        }, 5);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,4 @@
 enable_world:
   - ""
 dummy_health: 100
+dummy_respawn_delay: 100 #ticks


### PR DESCRIPTION
테스트 케이스: 

테스트:
- 리젠 주기가 정상적으로 적용되는지 확인하기
- 리젠이 된 후에도 config.yml에서 설정한 체력이 적용되는지 확인하기
- 서버를 껐다 킨 후에도 1번과 2번이 잘 작동되는지 확인하기
- 리젠 주기(Tick)를 음수로 설정해보기, 0으로 설정해보기
- Dummy에게 넉백이 적용되는지 확인하기 (몸으로 밀기, 때리기)
- Dummy가 햇빛 데미지에 영향을 받는지 확인하기
- config.yml에서 리젠 시간과 체력을 재설정 후 Reload 해보기
- Dummy를 여러개 생성해보고 렉이 발생하는지 확인하기
- Dummy 체력을 음수 혹은 0으로 설정해보기

결과:
- Dummy가 죽으면 config.yml에서 설정한 시간 뒤에 리젠됨.
- 리젠 후 config.yml에서 설정한 체력이 정상적으로 적용됨.
- 서버를 껐다 킨 후에도 리젠 시간과 체력 모두 정상적으로 적용됨.
- 리젠 주기를 음수 혹은 0으로 설정하여도 리젠 최소 주기인 21 ticks로 적용됨.
- dummy에게 넉백이 적용되지 않음.
- dummy가 햇빛으로부터 데미지를 받지 않음.
- Reload 후에 생성한 Dummy, Reload 전에 이미 스폰되어 있던 Dummy 모두 새 리젠 시간과 체력이 적용됨.
- Dummy를 20개 생성하였지만, 렉이 발생하지 않음.
- Dummy 체력이 음수 혹은 0이라면, 1로 적용됨.